### PR TITLE
Use flake-utils to make flake system-agnostic.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "luvit": {
       "flake": false,
       "locked": {
@@ -34,6 +49,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "luvit": "luvit",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,160 +1,172 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
+    flake-utils.url = "github:numtide/flake-utils";
     luvit = {
       url = "github:luvit/luvit";
       flake = false;
     };
   };
 
-  outputs = inputs@{ self, nixpkgs, luvit }: let
-    system = "aarch64-darwin";
-    pkgs = import nixpkgs { inherit system; };
+  outputs = inputs@{ self, nixpkgs, flake-utils, luvit }: let
     aiverson = {
       name = "Alex Iverson";
       email = "alexjiverson@gmail.com";
     };
-  in {
-    lib = with pkgs; with self.packages.${system}; rec {
-      makeLuviScript = name: source:
-        writeBinScript name "${luvi}/bin/luvi ${source} -- $@";
-      luviBase = writeScript "luvi" ''
-        #!${luvi}/bin/luvi --
-      '';
-      vendorLitDeps = { src, sha256, pname, ... }@args:
-        stdenv.mkDerivation({
-          name = "${pname}-vendoredpkgs";
-          buildInputs = [ lit curl cacert ];
-          phases = [ "unpackPhase" "configurePhase" "buildPhase" ];
-          buildPhase = ''
-            export HOME=./
-            mkdir -p $out
-            lit install || echo "work around bug"
-            cp -r ./deps $out
-          '';
+  in flake-utils.lib.eachDefaultSystem (system: 
+    let
+      pkgs = import nixpkgs { inherit system; };
+      selfPkgs = self.packages.${system};
+      selfLib = self.lib.${system};
+    in
+    {
+      lib = rec {
+        /*
+          Creates an executable script at /nix/store/<store path>/bin/<name>
+          which executes the lua script located at source using `luvi`.
+        */
+        makeLuviScript = name: source:
+          pkgs.writeScriptBin name "${selfPkgs.luvi}/bin/luvi ${source} -- $@";
 
-          inherit src;
+        luviBase = pkgs.writeScript "luvi" ''
+          #!${selfPkgs.luvi}/bin/luvi --
+        '';
 
-          outputHashMode = "recursive";
-          outputHashAlgo = "sha256";
-          outputHash = sha256;
-        });
+        vendorLitDeps = { src, sha256, pname, ... }@args:
+          pkgs.stdenv.mkDerivation({
+            name = "${pname}-vendoredpkgs";
+            buildInputs = with pkgs; [ selfPkgs.lit curl cacert ];
+            phases = [ "unpackPhase" "configurePhase" "buildPhase" ];
+            buildPhase = ''
+              export HOME=./
+              mkdir -p $out
+              lit install || echo "work around bug"
+              cp -r ./deps $out
+            '';
 
-      makeLitPackage = { buildInputs ? [ ], src, pname, litSha256, ... }@args:
-        let
-          deps = vendorLitDeps {
-            inherit src pname;
-            sha256 = litSha256;
+            inherit src;
+
+            outputHashMode = "recursive";
+            outputHashAlgo = "sha256";
+            outputHash = sha256;
+          });
+        
+        makeLitPackage = { buildInputs ? [ ], src, pname, litSha256, ... }@args:
+          let
+            deps = vendorLitDeps {
+              inherit src pname;
+              sha256 = litSha256;
+            };
+          in pkgs.stdenv.mkDerivation ({
+            buildPhase = ''
+              echo database: `pwd`/.litdb.git >> litconfig
+              export LIT_CONFIG=`pwd`/litconfig
+              ln -s ${deps}/deps ./deps
+              lit make . ./$pname ${luviBase} || echo "work around bug"
+            '';
+            installPhase = ''
+              mkdir -p $out/bin
+              cp ./$pname $out/bin/$pname
+            '';
+          } // args // {
+            buildInputs = with selfPkgs; [ lit luvi ] ++ buildInputs;
+          });
+      };
+
+      # defaultPackage is depricated in nix 2.13, using this for compatibility
+      defaultPackage = selfPkgs.default;
+
+      packages = rec {
+        default = luvit;
+
+        luvit = self.lib.${system}.makeLitPackage {
+          pname = "luvit";
+          version = "2.17.0";
+
+          litSha256 = "sha256-3EYdIjxF6XvFE3Ft6qpx/gaySMKiZi3kKr2K7QPB+G0=";
+
+          src = inputs.luvit;
+
+          meta = {
+            description = "a lua runtime for application";
+            homepage = "https://github.com/luvit/luvi";
+
+            license = pkgs.lib.licenses.apsl20;
+            maintainers = [ aiverson ];
           };
-        in stdenv.mkDerivation ({
-          buildPhase = ''
-            echo database: `pwd`/.litdb.git >> litconfig
-            export LIT_CONFIG=`pwd`/litconfig
-            ln -s ${deps}/deps ./deps
-            lit make . ./$pname ${luviBase} || echo "work around bug"
+        };
+
+        luvi = pkgs.stdenv.mkDerivation rec {
+          pname = "luvi";
+          version = "2.14.0";
+
+          src = pkgs.fetchFromGitHub {
+            owner = "luvit";
+            repo = "luvi";
+            rev = "v${version}";
+            sha256 = "sha256-c1rvRDHSU23KwrfEAu+fhouoF16Sla6hWvxyvUb5/Kg=";
+            fetchSubmodules = true;
+          };
+
+          buildInputs = with pkgs; [ cmake openssl ];
+
+          cmakeFlags = [
+            "-DWithOpenSSL=ON"
+            "-DWithSharedOpenSSL=ON"
+            "-DWithPCRE=ON"
+            "-DWithLPEG=ON"
+            "-DWithSharedPCRE=OFF"
+            "-DLUVI_VERSION=${version}"
+          ];
+
+          patchPhase = ''
+            echo ${version} >> VERSION
           '';
           installPhase = ''
             mkdir -p $out/bin
-            cp ./$pname $out/bin/$pname
+            cp luvi $out/bin/luvi
           '';
-        } // args // {
-          buildInputs = [ lit luvi ] ++ buildInputs;
-        });
-    };
 
-    # Specify the default package
-    defaultPackage.${system} = self.packages.${system}.luvit;
+          meta = {
+            description = "a lua runtime for applications";
+            homepage = "https://github.com/luvit/luvi";
 
-    packages.${system} = with pkgs; with self.lib; rec {
-      luvit = makeLitPackage rec {
-        pname = "luvit";
-        version = "2.17.0";
+            license = pkgs.lib.licenses.apsl20;
+            maintainers = [ aiverson ];
+          };
+        };
 
-        litSha256 = "sha256-3EYdIjxF6XvFE3Ft6qpx/gaySMKiZi3kKr2K7QPB+G0=";
+        lit = pkgs.stdenv.mkDerivation rec {
+          pname = "lit";
+          version = "3.8.5";
 
-        src = inputs.luvit;
+          src = pkgs.fetchFromGitHub {
+            owner = "luvit";
+            repo = "lit";
+            rev = "${version}";
+            sha256 = "sha256-8Fy1jIDNSI/bYHmiGPEJipTEb7NYCbN3LsrME23sLqQ=";
+            fetchSubmodules = true;
+          };
 
-        meta = {
-          description = "a lua runtime for application";
-          homepage = "https://github.com/luvit/luvi";
+          buildInputs = [ selfPkgs.luvi ];
+          buildPhase = ''
+            echo database: `pwd`/.litdb.git >> litconfig
+            export LIT_CONFIG=`pwd`/litconfig
+            ${selfPkgs.luvi}/bin/luvi . -- make . ./lit ${selfLib.luviBase} || echo work around bug
+          '';
+          installPhase = ''
+            mkdir -p $out/bin
+            cp lit $out/bin/lit
+          '';
 
-          license = pkgs.lib.licenses.apsl20;
-          maintainers = [ aiverson ];
+          meta = {
+            description = "packaging tool for luvit";
+            homepage = "https://github.com/luvit/lit";
+
+            license = pkgs.lib.licenses.apsl20;
+            maintainers = [ aiverson ];
+          };
         };
       };
-
-      luvi = stdenv.mkDerivation rec {
-        pname = "luvi";
-        version = "2.14.0";
-
-        src = pkgs.fetchFromGitHub {
-          owner = "luvit";
-          repo = "luvi";
-          rev = "v${version}";
-          sha256 = "h9Xdm/+9X3AoqBj1LJftqn3+3PbdankfAJSBP3KnRgw=";
-          fetchSubmodules = true;
-        };
-
-        buildInputs = [ cmake openssl ];
-
-        cmakeFlags = [
-          "-DWithOpenSSL=ON"
-          "-DWithSharedOpenSSL=ON"
-          "-DWithPCRE=ON"
-          "-DWithLPEG=ON"
-          "-DWithSharedPCRE=OFF"
-          "-DLUVI_VERSION=${version}"
-        ];
-
-        patchPhase = ''
-          echo ${version} >> VERSION
-        '';
-        installPhase = ''
-          mkdir -p $out/bin
-          cp luvi $out/bin/luvi
-        '';
-
-        meta = {
-          description = "a lua runtime for applications";
-          homepage = "https://github.com/luvit/luvi";
-
-          license = pkgs.lib.licenses.apsl20;
-          maintainers = [ aiverson ];
-        };
-      };
-
-
-      lit = stdenv.mkDerivation rec {
-        pname = "lit";
-        version = "3.8.5";
-
-        src = pkgs.fetchFromGitHub {
-          owner = "luvit";
-          repo = "lit";
-          rev = "${version}";
-          sha256 = "sha256-8Fy1jIDNSI/bYHmiGPEJipTEb7NYCbN3LsrME23sLqQ=";
-          fetchSubmodules = true;
-        };
-
-        buildInputs = [ luvi ];
-        buildPhase = ''
-          echo database: `pwd`/.litdb.git >> litconfig
-          export LIT_CONFIG=`pwd`/litconfig
-          ${luvi}/bin/luvi . -- make . ./lit ${luviBase} || echo work around bug
-        '';
-        installPhase = ''
-          mkdir -p $out/bin
-          cp lit $out/bin/lit
-        '';
-
-        meta = {
-          description = "packaging tool for luvit";
-          homepage = "https://github.com/luvit/lit";
-
-          license = pkgs.lib.licenses.apsl20;
-          maintainers = [ aiverson ];
-        };
-      };
-    };
-  };
+    });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,7 @@
 
       luvi = stdenv.mkDerivation rec {
         pname = "luvi";
-        version = "2.13.0";
+        version = "2.14.0";
 
         src = pkgs.fetchFromGitHub {
           owner = "luvit";

--- a/flake.nix
+++ b/flake.nix
@@ -8,9 +8,8 @@
   };
 
   outputs = inputs@{ self, nixpkgs, luvit }: let
-    pkgs = import nixpkgs {
-      system = "x86_64-linux";
-    };
+    system = "aarch64-darwin";
+    pkgs = import nixpkgs { inherit system; };
     aiverson = {
       name = "Alex Iverson";
       email = "alexjiverson@gmail.com";
@@ -64,9 +63,9 @@
     };
 
     # Specify the default package
-    defaultPackage.x86_64-linux = self.packages.x86_64-linux.luvit;
+    defaultPackage.${system} = self.packages.${system}.luvit;
 
-    packages.x86_64-linux = with pkgs; with self.lib; rec {
+    packages.${system} = with pkgs; with self.lib; rec {
       luvit = makeLitPackage rec {
         pname = "luvit";
         version = "2.17.0";

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,6 @@
 
           license = pkgs.lib.licenses.apsl20;
           maintainers = [ aiverson ];
-          platforms = pkgs.lib.platforms.linux;
         };
       };
 
@@ -121,7 +120,6 @@
 
           license = pkgs.lib.licenses.apsl20;
           maintainers = [ aiverson ];
-          platforms = pkgs.lib.platforms.linux;
         };
       };
 
@@ -138,7 +136,7 @@
           fetchSubmodules = true;
         };
 
-        buildInputs = [ luvi strace ];
+        buildInputs = [ luvi ];
         buildPhase = ''
           echo database: `pwd`/.litdb.git >> litconfig
           export LIT_CONFIG=`pwd`/litconfig
@@ -155,7 +153,6 @@
 
           license = pkgs.lib.licenses.apsl20;
           maintainers = [ aiverson ];
-          platforms = pkgs.lib.platforms.linux;
         };
       };
     };


### PR DESCRIPTION
Wraps the attrset in the flake output with `eachDefaultSystem` in order to allow the flake to be built on more systems.

This does introduce a breaking change: `lib` is now discriminated by a system tuple, i.e to call `makeLitPackage` one now needs to use `lib.<system>.makeLitPackage`. This is because the items in `lib` are tightly coupled with `packages` which is now multi-system. 